### PR TITLE
Named rvalue references are treated as lvalue references

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,8 +731,6 @@ decltype(a) b = a; // `decltype(a)` is `int`
 const int& c = a; // `c` is declared as type `const int&`
 decltype(c) d = a; // `decltype(c)` is `const int&`
 decltype(123) e = 123; // `decltype(123)` is `int`
-int&& f = 1; // `f` is declared as type `int&&`
-decltype(f) g = 1; // `decltype(f) is `int&&`
 decltype((a)) h = g; // `decltype((a))` is int&
 ```
 ```c++


### PR DESCRIPTION
In `int&& f = 1;`, `f` is not an xvalue in spite of being declared as an rvalue reference, and because it's a named variable its "rvaluness" is ignored.  From the point of definition onward, the compiler will treat it as an lvalue reference.

Technically, `decltype(static_cast<int&&>(f))` or `decltype(std::move(f))` should emit an rvalue reference but in a statement like `decltype(std::move(f)) g = 1;`, the "rvalueness"
is again lost because it is part of a named variable.

From [N3055: A Taxonomy of Expression Value Categories](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3055.pdf), included in the C++11 standard:

> [Note: An expression is an xvalue if it is:
> - the result of calling a function, whether implicitly or explicitly, whose return type is
an rvalue reference to object type,
> - a cast to an rvalue reference to object type,
> - a class member access expression designating a non-static data member in which
the object expression is an xvalue, or
> - a .* pointer-to-member expression in which the first operand is an xvalue and the
second operand is a pointer to data member.
> 
> **In general, the effect of this rule is that named rvalue references are treated as lvalues and unnamed rvalue references to objects are treated as xvalues;** rvalue references to
functions are treated as lvalues whether named or not. —end note]

Also see: https://stackoverflow.com/a/17242295/6834058

Note, the following code:

```
#include <iostream>

void printtype(int& ref) {
        std::cout << "lvalue reference to " << ref << " was passed." << std::endl;
}
void printtype(int&& ref) {
        std::cout << "rvalue reference to " << ref << " was passed." << std::endl;
}

int main() {
        int&& f = 1;
        decltype(std::move(f)) g = 2;
        printtype(f);
        printtype(g);
        printtype(std::move(f));
        printtype(std::move(g));
}
```
Prints:

>lvalue reference to 1 was passed.
lvalue reference to 2 was passed.
rvalue reference to 1 was passed.
rvalue reference to 2 was passed.