### PR TITLE
Revert "Named rvalue references are treated as lvalue references"

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,6 +731,8 @@ decltype(a) b = a; // `decltype(a)` is `int`
 const int& c = a; // `c` is declared as type `const int&`
 decltype(c) d = a; // `decltype(c)` is `const int&`
 decltype(123) e = 123; // `decltype(123)` is `int`
+int&& f = 1; // `f` is declared as type `int&&`
+decltype(f) g = 1; // `decltype(f) is `int&&`
 decltype((a)) h = g; // `decltype((a))` is int&
 ```
 ```c++


### PR DESCRIPTION
Reverts AnthonyCalandra/modern-cpp-features#26