### PR TITLE
fixed typos

### DIFF
--- a/CPP11.md
+++ b/CPP11.md
@@ -456,7 +456,7 @@ struct A {
   A(int) {}
 };
 
-A a(1.1); // OK
+A a(1); // OK
 A b{1.1}; // Error narrowing conversion from double to int
 ```
 


### PR DESCRIPTION
I think on a line 459 is a typo:
instead of  A a(1.1); // OK 
should be  A a(1); // OK