### PR TITLE
Use std::size instead of sizeof in string_view example

### DIFF
--- a/CPP17.md
+++ b/CPP17.md
@@ -287,7 +287,7 @@ std::string_view cppstr{ "foo" };
 std::wstring_view wcstr_v{ L"baz" };
 // Character arrays.
 char array[3] = {'b', 'a', 'r'};
-std::string_view array_v(array, sizeof array);
+std::string_view array_v(array, std::size(array));
 ```
 ```c++
 std::string str{ "   trim me" };

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ std::string_view cppstr{ "foo" };
 std::wstring_view wcstr_v{ L"baz" };
 // Character arrays.
 char array[3] = {'b', 'a', 'r'};
-std::string_view array_v(array, sizeof array);
+std::string_view array_v(array, std::size(array));
 ```
 ```c++
 std::string str{ "   trim me" };


### PR DESCRIPTION
### Motivation
It's generally safer to use `std::size` or `array.size()` here instead of `sizeof`.
This `string_view` constructor:
```
constexpr basic_string_view(const charT* str, size_type len);
```
According to `C++ 17/[string.view.cons]`
```
Requires: [str, str + len) is a valid range.
```
According to [cppreference](https://en.cppreference.com/w/cpp/string/basic_string_view/basic_string_view)
```
The behavior is undefined if [str, str+len) is not a valid range (even though the constructor may not access any of the elements of this range).
```

Though the example here is right, but after some modification to let it fit to `wstring_view`
```
// Character arrays. 
wchar_t array[3] = {'b', 'a', 'r'}; 
sizeof array > 3; // true
std::wstring_view array_v(array, sizeof array); // Undefined behavior! [array, array+sizeof array) is not a valid range!
```
So I would the `string_view` example to use `std::size` instead of `sizeof` to avoid misuse by others.