### PR TITLE
"Template aliases" have been renamed to "Type aliases" in CPP11.md and README.md files

### DIFF
--- a/CPP11.md
+++ b/CPP11.md
@@ -13,7 +13,7 @@ C++11 includes the following new language features:
 - [auto](#auto)
 - [lambda expressions](#lambda-expressions)
 - [decltype](#decltype)
-- [template aliases](#template-aliases)
+- [type aliases](#type-aliases)
 - [nullptr](#nullptr)
 - [strongly-typed enums](#strongly-typed-enums)
 - [attributes](#attributes)
@@ -243,8 +243,8 @@ add(1, 2.0); // `decltype(x + y)` => `decltype(3.0)` => `double`
 
 See also: `decltype(auto)` (C++14).
 
-### Template aliases
-Semantically similar to using a `typedef` however, template aliases with `using` are easier to read and are compatible with templates.
+### Type aliases
+Semantically similar to using a `typedef` however, type aliases with `using` are easier to read and are compatible with templates.
 ```c++
 template <typename T>
 using Vec = std::vector<T>;

--- a/README.md
+++ b/README.md
@@ -1054,8 +1054,8 @@ add(1, 2.0); // `decltype(x + y)` => `decltype(3.0)` => `double`
 
 See also: [`decltype(auto)`](#decltypeauto).
 
-### Template aliases
-Semantically similar to using a `typedef` however, template aliases with `using` are easier to read and are compatible with templates.
+### Type aliases
+Semantically similar to using a `typedef` however, type aliases with `using` are easier to read and are compatible with templates.
 ```c++
 template <typename T>
 using Vec = std::vector<T>;

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ C++11 includes the following new language features:
 - [auto](#auto)
 - [lambda expressions](#lambda-expressions)
 - [decltype](#decltype)
-- [template aliases](#template-aliases)
+- [type aliases](#type-aliases)
 - [nullptr](#nullptr)
 - [strongly-typed enums](#strongly-typed-enums)
 - [attributes](#attributes)


### PR DESCRIPTION
"Type aliases" are the correct name of the feature, not "Template aliases". 