### PR TITLE
Add More Examples to Some Sections

### DIFF
--- a/CPP14.md
+++ b/CPP14.md
@@ -35,15 +35,6 @@ auto identity = [](auto x) { return x; };
 int three = identity(3); // == 3
 std::string foo = identity("foo"); // == "foo"
 ```
-```c++
-auto Plus = [](auto x, auto y) { return x + y; };
-
-auto a = Plus(1.0, 1.0); // deduced to be double 2.0
-auto b = Plus(1, 1);     // deduced to be int 2  
-
-using namespace std::string_literals;
-auto c = Plus("Hello"s, " World!"s); // deduced to be string "Hello World!"
-```
 
 ### Lambda capture initializers
 This allows creating lambda captures initialized with arbitrary expressions. The name given to the captured value does not need to be related to any variables in the enclosing scopes and introduces a new name inside the lambda body. The initializing expression is evaluated when the lambda is _created_ (not when it is _invoked_).

--- a/CPP14.md
+++ b/CPP14.md
@@ -35,6 +35,15 @@ auto identity = [](auto x) { return x; };
 int three = identity(3); // == 3
 std::string foo = identity("foo"); // == "foo"
 ```
+```c++
+auto Plus = [](auto x, auto y) { return x + y; };
+
+auto a = Plus(1.0, 1.0); // deduced to be double 2.0
+auto b = Plus(1, 1);     // deduced to be int 2  
+
+using namespace std::string_literals;
+auto c = Plus("Hello"s, " World!"s); // deduced to be string "Hello World!"
+```
 
 ### Lambda capture initializers
 This allows creating lambda captures initialized with arbitrary expressions. The name given to the captured value does not need to be related to any variables in the enclosing scopes and introduces a new name inside the lambda body. The initializing expression is evaluated when the lambda is _created_ (not when it is _invoked_).

--- a/CPP17.md
+++ b/CPP17.md
@@ -185,8 +185,9 @@ std::unordered_map<std::string, int> mapping {
   {"c", 3},
 };
 
-for (const auto [key, value] : mapping) {
-  // do something with key and value
+// Destructure by reference.
+for (const auto& [key, value] : mapping) {
+  // Do something with key and value
 }
 ```
 

--- a/CPP17.md
+++ b/CPP17.md
@@ -178,6 +178,17 @@ const auto [ x, y ] = origin();
 x; // == 0
 y; // == 0
 ```
+```c++
+std::unordered_map<std::string, int> mapping {
+  {"a", 1},
+  {"b", 2},
+  {"c", 3},
+};
+
+for (const auto [key, value] : mapping) {
+  // do something with key and value
+}
+```
 
 ### Selection statements with initializer
 New versions of the `if` and `switch` statements which simplify common code patterns and help users keep scopes tight.

--- a/README.md
+++ b/README.md
@@ -436,8 +436,9 @@ std::unordered_map<std::string, int> mapping {
   {"c", 3},
 };
 
-for (const auto [key, value] : mapping) {
-  // do something with key and value
+// Destructure by reference.
+for (const auto& [key, value] : mapping) {
+  // Do something with key and value
 }
 ```
 
@@ -705,15 +706,6 @@ C++14 now allows the `auto` type-specifier in the parameter list, enabling polym
 auto identity = [](auto x) { return x; };
 int three = identity(3); // == 3
 std::string foo = identity("foo"); // == "foo"
-```
-```c++
-auto Plus = [](auto x, auto y) { return x + y; };
-
-auto a = Plus(1.0, 1.0); // deduced to be double 2.0
-auto b = Plus(1, 1);     // deduced to be int 2
-
-using namespace std::string_literals;
-auto c = Plus("Hello"s, " World!"s); // deduced to be string "Hello World!"
 ```
 
 ### Lambda capture initializers

--- a/README.md
+++ b/README.md
@@ -429,6 +429,17 @@ const auto [ x, y ] = origin();
 x; // == 0
 y; // == 0
 ```
+```c++
+std::unordered_map<std::string, int> mapping {
+  {"a", 1}, 
+  {"b", 2}, 
+  {"c", 3},
+};
+
+for (const auto [key, value] : mapping) {
+  // do something with key and value
+}
+```
 
 ### Selection statements with initializer
 New versions of the `if` and `switch` statements which simplify common code patterns and help users keep scopes tight.

--- a/README.md
+++ b/README.md
@@ -706,6 +706,15 @@ auto identity = [](auto x) { return x; };
 int three = identity(3); // == 3
 std::string foo = identity("foo"); // == "foo"
 ```
+```c++
+auto Plus = [](auto x, auto y) { return x + y; };
+
+auto a = Plus(1.0, 1.0); // deduced to be double 2.0
+auto b = Plus(1, 1);     // deduced to be int 1.0
+
+using namespace std::string_literals;
+auto c = Plus("Hello"s, " World!"s); // deduced to be string "Hello World!"
+```
 
 ### Lambda capture initializers
 This allows creating lambda captures initialized with arbitrary expressions. The name given to the captured value does not need to be related to any variables in the enclosing scopes and introduces a new name inside the lambda body. The initializing expression is evaluated when the lambda is _created_ (not when it is _invoked_).

--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ std::string foo = identity("foo"); // == "foo"
 auto Plus = [](auto x, auto y) { return x + y; };
 
 auto a = Plus(1.0, 1.0); // deduced to be double 2.0
-auto b = Plus(1, 1);     // deduced to be int 1.0
+auto b = Plus(1, 1);     // deduced to be int 2
 
 using namespace std::string_literals;
 auto c = Plus("Hello"s, " World!"s); // deduced to be string "Hello World!"


### PR DESCRIPTION
Added an example to structured bindings to demonstrate that this can also be done in loops and with map types. I use this often in debugging and it is much nicer than using the iterator first and second syntax.

Added an example to Generic Lambda Expressions to show an example with more than one deduced argument.