### PR TITLE
Fix definition of final specifier

### DIFF
--- a/CPP11.md
+++ b/CPP11.md
@@ -386,7 +386,7 @@ struct B : A {
 ```
 
 ### Final specifier
-Specifies that a virtual function cannot be overridden in a derived class or that a class cannot be inherited from.
+Specifies that a function cannot be overridden in a derived class or that a class cannot be inherited from.
 ```c++
 struct A {
   virtual void foo();


### PR DESCRIPTION
1. As explained here: https://en.cppreference.com/w/cpp/language/final, final works whether a function is virtual or not.
2. Isn't `virtual final` kinda redundant? Why would you allow overriding with `virtual`, then disallow it with `final`?