### PR TITLE
Update README.md

### DIFF
--- a/CPP14.md
+++ b/CPP14.md
@@ -169,7 +169,7 @@ std::chrono::duration_cast<std::chrono::minutes>(day).count(); // == 1440
 
 ### Compile-time integer sequences
 The class template `std::integer_sequence` represents a compile-time sequence of integers. There are a few helpers built on top:
-* `std::make_integer_sequence<T, N...>` - creates a sequence of `0, ..., N - 1` with type `T`.
+* `std::make_integer_sequence<T, N>` - creates a sequence of `0, ..., N - 1` with type `T`.
 * `std::index_sequence_for<T...>` - converts a template parameter pack into an integer sequence.
 
 Convert an array into a tuple:

--- a/README.md
+++ b/README.md
@@ -1126,7 +1126,7 @@ std::chrono::duration_cast<std::chrono::minutes>(day).count(); // == 1440
 
 ### Compile-time integer sequences
 The class template `std::integer_sequence` represents a compile-time sequence of integers. There are a few helpers built on top:
-* `std::make_integer_sequence<T, N...>` - creates a sequence of `0, ..., N - 1` with type `T`.
+* `std::make_integer_sequence<T, N>` - creates a sequence of `0, ..., N - 1` with type `T`.
 * `std::index_sequence_for<T...>` - converts a template parameter pack into an integer sequence.
 
 Convert an array into a tuple:


### PR DESCRIPTION
As per https://en.cppreference.com/w/cpp/utility/integer_sequence, `std::make_integer_sequence` doesn't accept any parameter pack template arguments