### PR TITLE
Fix typo: Correct argument name in enum namespace example.

### DIFF
--- a/CPP20.md
+++ b/CPP20.md
@@ -329,7 +329,7 @@ After:
 ```c++
 enum class rgba_color_channel { red, green, blue, alpha };
 
-std::string_view to_string(rgba_color_channel channel) {
+std::string_view to_string(rgba_color_channel my_channel) {
   switch (my_channel) {
     using enum rgba_color_channel;
     case red:   return "red";

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ After:
 ```c++
 enum class rgba_color_channel { red, green, blue, alpha };
 
-std::string_view to_string(rgba_color_channel channel) {
+std::string_view to_string(rgba_color_channel my_channel) {
   switch (my_channel) {
     using enum rgba_color_channel;
     case red:   return "red";


### PR DESCRIPTION
Signed-off-by: Andreas Hofmann <mail@andreas-hofmann.org>