### PR TITLE
Added raw string literals to C++11 features

### DIFF
--- a/CPP11.md
+++ b/CPP11.md
@@ -701,7 +701,9 @@ char16_t utf8_str[] = u"\u0123";
 C++11 introduces a new way to declare string literals as "raw string literals". Characters issued from an escape sequence (tabs, line feeds, single backslashes, etc.) can be inputted raw while preserving formatting. This is useful, for example, to write literary text, which might contain a lot of quotes or special formatting. This can make your string literals easier to read and maintain.
 
 A raw string literal is declared using the following syntax:
+
 	`R"delimiter(raw_characters)delimiter"`
+
 where:
 * `delimiter` is an optional sequence of characters made of any source character except parentheses, backslashes and spaces.
 * `raw_characters` is any raw character sequence; must not contain the closing sequence `")delimiter"`.

--- a/CPP11.md
+++ b/CPP11.md
@@ -35,6 +35,7 @@ C++11 includes the following new language features:
 - [trailing return types](#trailing-return-types)
 - [noexcept specifier](#noexcept-specifier)
 - [char32_t and char16_t](#char32_t-and-char16_t)
+- [raw string literals](#raw-string-literals)
 
 C++11 includes the following new library features:
 - [std::move](#stdmove)
@@ -694,6 +695,34 @@ Provides standard types for representing UTF-8 strings.
 ```c++
 char32_t utf8_str[] = U"\u0123";
 char16_t utf8_str[] = u"\u0123";
+```
+
+### Raw string literals
+C++11 introduces a new way to declare string literals called "Raw string literals". As their name implies, characters issued from an escape sequence (tabs, line feeds, single backslashes...) can be inputted raw. While, of course, this inevitably prevents the usage of escape characters (`'\n'`, `'\t'` or `'\0'`...), it gives a great advantage if you want, for example, to write template code inside a string literal, or write literary text, which might contain a lot of quotes. This can make your string literals easier to read (mainly if they contain many tabs).
+
+A raw string literal is declared using the following syntax :
+	`prefix(optional) R"delimiter(raw_characters)delimiter"`
+
+where :
+* `prefix` is one of `L`, `u8`, `u`, `U` (`u8`, `u` and `U` were also added in C++11).
+* `delimiter` is a sequence of characters made of any source character BUT parentheses, backslashes and spaces. It can be empty, and at most 16 characters long.
+* `raw_characters` is any raw character sequence. Obviously, it must not contain the closing sequence `")delimiter"`.
+
+
+
+Example :
+```cpp
+/*
+ * In this example, msg1 and msg2 are equivalent. Printing them to the screen or a file will
+ * give the same result.
+ */
+
+const char* msg1 = "\nHello,\n\tworld!\n";
+
+const char* msg2 = R"(
+Hello,
+	world!
+)";
 ```
 
 ## C++11 Library Features

--- a/CPP11.md
+++ b/CPP11.md
@@ -701,9 +701,9 @@ char16_t utf8_str[] = u"\u0123";
 C++11 introduces a new way to declare string literals as "raw string literals". Characters issued from an escape sequence (tabs, line feeds, single backslashes, etc.) can be inputted raw while preserving formatting. This is useful, for example, to write literary text, which might contain a lot of quotes or special formatting. This can make your string literals easier to read and maintain.
 
 A raw string literal is declared using the following syntax:
-
-	`R"delimiter(raw_characters)delimiter"`
-
+```
+R"delimiter(raw_characters)delimiter"
+```
 where:
 * `delimiter` is an optional sequence of characters made of any source character except parentheses, backslashes and spaces.
 * `raw_characters` is any raw character sequence; must not contain the closing sequence `")delimiter"`.

--- a/CPP11.md
+++ b/CPP11.md
@@ -698,27 +698,18 @@ char16_t utf8_str[] = u"\u0123";
 ```
 
 ### Raw string literals
-C++11 introduces a new way to declare string literals called "Raw string literals". As their name implies, characters issued from an escape sequence (tabs, line feeds, single backslashes...) can be inputted raw. While, of course, this inevitably prevents the usage of escape characters (`'\n'`, `'\t'` or `'\0'`...), it gives a great advantage if you want, for example, to write template code inside a string literal, or write literary text, which might contain a lot of quotes. This can make your string literals easier to read (mainly if they contain many tabs).
+C++11 introduces a new way to declare string literals as "raw string literals". Characters issued from an escape sequence (tabs, line feeds, single backslashes, etc.) can be inputted raw while preserving formatting. This is useful, for example, to write literary text, which might contain a lot of quotes or special formatting. This can make your string literals easier to read and maintain.
 
-A raw string literal is declared using the following syntax :
-	`prefix(optional) R"delimiter(raw_characters)delimiter"`
+A raw string literal is declared using the following syntax:
+	`R"delimiter(raw_characters)delimiter"`
+where:
+* `delimiter` is an optional sequence of characters made of any source character except parentheses, backslashes and spaces.
+* `raw_characters` is any raw character sequence; must not contain the closing sequence `")delimiter"`.
 
-where :
-* `prefix` is one of `L`, `u8`, `u`, `U` (`u8`, `u` and `U` were also added in C++11).
-* `delimiter` is a sequence of characters made of any source character BUT parentheses, backslashes and spaces. It can be empty, and at most 16 characters long.
-* `raw_characters` is any raw character sequence. Obviously, it must not contain the closing sequence `")delimiter"`.
-
-
-
-Example :
+Example:
 ```cpp
-/*
- * In this example, msg1 and msg2 are equivalent. Printing them to the screen or a file will
- * give the same result.
- */
-
+// msg1 and msg2 are equivalent.
 const char* msg1 = "\nHello,\n\tworld!\n";
-
 const char* msg2 = R"(
 Hello,
 	world!

--- a/README.md
+++ b/README.md
@@ -1937,9 +1937,9 @@ char16_t utf8_str[] = u"\u0123";
 C++11 introduces a new way to declare string literals as "raw string literals". Characters issued from an escape sequence (tabs, line feeds, single backslashes, etc.) can be inputted raw while preserving formatting. This is useful, for example, to write literary text, which might contain a lot of quotes or special formatting. This can make your string literals easier to read and maintain.
 
 A raw string literal is declared using the following syntax:
-
-	`R"delimiter(raw_characters)delimiter"`
-
+```
+R"delimiter(raw_characters)delimiter"
+```
 where:
 * `delimiter` is an optional sequence of characters made of any source character except parentheses, backslashes and spaces.
 * `raw_characters` is any raw character sequence; must not contain the closing sequence `")delimiter"`.

--- a/README.md
+++ b/README.md
@@ -1934,27 +1934,18 @@ char16_t utf8_str[] = u"\u0123";
 ```
 
 ### Raw string literals
-C++11 introduces a new way to declare string literals called "Raw string literals". As their name implies, characters issued from an escape sequence (tabs, line feeds, single backslashes...) can be inputted raw. While, of course, this inevitably prevents the usage of escape characters (`'\n'`, `'\t'` or `'\0'`...), it gives a great advantage if you want, for example, to write template code inside a string literal, or write literary text, which might contain a lot of quotes. This can make your string literals easier to read (mainly if they contain many tabs).
+C++11 introduces a new way to declare string literals as "raw string literals". Characters issued from an escape sequence (tabs, line feeds, single backslashes, etc.) can be inputted raw while preserving formatting. This is useful, for example, to write literary text, which might contain a lot of quotes or special formatting. This can make your string literals easier to read and maintain.
 
-A raw string literal is declared using the following syntax :
-	`prefix(optional) R"delimiter(raw_characters)delimiter"`
+A raw string literal is declared using the following syntax:
+	`R"delimiter(raw_characters)delimiter"`
+where:
+* `delimiter` is an optional sequence of characters made of any source character except parentheses, backslashes and spaces.
+* `raw_characters` is any raw character sequence; must not contain the closing sequence `")delimiter"`.
 
-where :
-* `prefix` is one of `L`, `u8`, `u`, `U` (`u8`, `u` and `U` were also added in C++11).
-* `delimiter` is a sequence of characters made of any source character BUT parentheses, backslashes and spaces. It can be empty, and at most 16 characters long.
-* `raw_characters` is any raw character sequence. Obviously, it must not contain the closing sequence `")delimiter"`.
-
-
-
-Example :
+Example:
 ```cpp
-/*
- * In this example, msg1 and msg2 are equivalent. Printing them to the screen or a file will
- * give the same result.
- */
-
+// msg1 and msg2 are equivalent.
 const char* msg1 = "\nHello,\n\tworld!\n";
-
 const char* msg2 = R"(
 Hello,
 	world!

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ C++11 includes the following new language features:
 - [trailing return types](#trailing-return-types)
 - [noexcept specifier](#noexcept-specifier)
 - [char32_t and char16_t](#char32_t-and-char16_t)
+- [raw string literals](#raw-string-literals)
 
 C++11 includes the following new library features:
 - [std::move](#stdmove)

--- a/README.md
+++ b/README.md
@@ -1937,7 +1937,9 @@ char16_t utf8_str[] = u"\u0123";
 C++11 introduces a new way to declare string literals as "raw string literals". Characters issued from an escape sequence (tabs, line feeds, single backslashes, etc.) can be inputted raw while preserving formatting. This is useful, for example, to write literary text, which might contain a lot of quotes or special formatting. This can make your string literals easier to read and maintain.
 
 A raw string literal is declared using the following syntax:
+
 	`R"delimiter(raw_characters)delimiter"`
+
 where:
 * `delimiter` is an optional sequence of characters made of any source character except parentheses, backslashes and spaces.
 * `raw_characters` is any raw character sequence; must not contain the closing sequence `")delimiter"`.

--- a/README.md
+++ b/README.md
@@ -1933,6 +1933,34 @@ char32_t utf8_str[] = U"\u0123";
 char16_t utf8_str[] = u"\u0123";
 ```
 
+### Raw string literals
+C++11 introduces a new way to declare string literals called "Raw string literals". As their name implies, characters issued from an escape sequence (tabs, line feeds, single backslashes...) can be inputted raw. While, of course, this inevitably prevents the usage of escape characters (`'\n'`, `'\t'` or `'\0'`...), it gives a great advantage if you want, for example, to write template code inside a string literal, or write literary text, which might contain a lot of quotes. This can make your string literals easier to read (mainly if they contain many tabs).
+
+A raw string literal is declared using the following syntax :
+	`prefix(optional) R"delimiter(raw_characters)delimiter"`
+
+where :
+* `prefix` is one of `L`, `u8`, `u`, `U` (`u8`, `u` and `U` were also added in C++11).
+* `delimiter` is a sequence of characters made of any source character BUT parentheses, backslashes and spaces. It can be empty, and at most 16 characters long.
+* `raw_characters` is any raw character sequence. Obviously, it must not contain the closing sequence `")delimiter"`.
+
+
+
+Example :
+```cpp
+/*
+ * In this example, msg1 and msg2 are equivalent. Printing them to the screen or a file will
+ * give the same result.
+ */
+
+const char* msg1 = "\nHello,\n\tworld!\n";
+
+const char* msg2 = R"(
+Hello,
+	world!
+)";
+```
+
 ## C++11 Library Features
 
 ### std::move


### PR DESCRIPTION
As pointed out in issue #75 , raw string literals were added in C++11, but were missing in the features list. I have written a short description of raw string literals, their declaration syntax, and a usage example, comparing with a classing string literal. In this example, I made use of line feeds and tabs escape sequences to clearly show the difference between C++11's new literals and the old ones. I have added my paragraph to CPP11.md and README.md.
I hope that my contribution (if particularly small) will suit your project, and I hope it will keep growing from more contributions.

Best regards,
David.