### PR TITLE
Proofreading and fix cross-document link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ I'm not very picky about how you should contribute, but I ask that the following
 example of its usage. An optimal submission would also include a short real-world use case for the feature.
 * Make sure the feature is in the correct C++ version.
 * Make sure you've added the feature to the table of contents.
-* Make sure you have also added the feature to the separate major C++ readme files (ie. CPP11.md, CPP14.md, etc.).
+* Make sure you have also added the feature to the separate major C++ readme files (i.e. CPP11.md, CPP14.md, etc.).
 * Keep additions/deletions of content consistent with the cheatsheet's goals.
 
 ## Goals

--- a/CPP11.md
+++ b/CPP11.md
@@ -805,7 +805,7 @@ static_assert(std::is_same<std::conditional<true, int, double>::type, int>::valu
 ### Smart pointers
 C++11 introduces new smart pointers: `std::unique_ptr`, `std::shared_ptr`, `std::weak_ptr`. `std::auto_ptr` now becomes deprecated and then eventually removed in C++17.
 
-`std::unique_ptr` is a non-copyable, movable pointer that manages its own heap-allocated memory. **Note: Prefer using the `std::make_X` helper functions as opposed to using constructors. See the sections for [std::make_unique](#stdmake_unique) and [std::make_shared](#stdmake_shared).**
+`std::unique_ptr` is a non-copyable, movable pointer that manages its own heap-allocated memory. **Note: Prefer using the `std::make_X` helper functions as opposed to using constructors. See the sections for [std::make_unique](https://github.com/AnthonyCalandra/modern-cpp-features/blob/master/CPP14.md#stdmake_unique) and [std::make_shared](#stdmake_shared).**
 ```c++
 std::unique_ptr<Foo> p1 { new Foo{} };  // `p1` owns `Foo`
 if (p1) {
@@ -952,7 +952,7 @@ auto result = handle.get();  // wait for the result
 ```
 
 ### std::begin/end
-`std::begin` and `std::end` free functions were added to return begin and end iterators of a container generically. These functions also work with raw arrays which do not have begin and end member functions.
+`std::begin` and `std::end` free functions were added to return begin and end iterators of a container generically. These functions also work with raw arrays which do not have `begin` and `end` member functions.
 
 ```c++
 template <typename T>

--- a/CPP14.md
+++ b/CPP14.md
@@ -148,7 +148,7 @@ constexpr T e  = T(2.7182818284590452353);
 ```
 
 ### [[deprecated]] attribute
-C++14 introduces the `[[deprecated]]` attribute to indicate that a unit (function, class, etc) is discouraged and likely yield compilation warnings. If a reason is provided, it will be included in the warnings.
+C++14 introduces the `[[deprecated]]` attribute to indicate that a unit (function, class, etc.) is discouraged and likely yield compilation warnings. If a reason is provided, it will be included in the warnings.
 ```c++
 [[deprecated]]
 void old_method();

--- a/CPP20.md
+++ b/CPP20.md
@@ -153,7 +153,7 @@ auto g = []<my_concept auto v> () {
   // ...
 };
 ```
-The `requires` keyword is used either to start a requires clause or a requires expression:
+The `requires` keyword is used either to start a `requires` clause or a `requires` expression:
 ```c++
 template <typename T>
   requires my_concept<T> // `requires` clause.
@@ -168,7 +168,7 @@ T add(T a, T b) {
   return a + b;
 }
 ```
-Note that the parameter list in a requires expression is optional. Each requirement in a requires expression are one of the following:
+Note that the parameter list in a `requires` expression is optional. Each requirement in a `requires` expression are one of the following:
 
 * **Simple requirements** - asserts that the given expression is valid.
 
@@ -297,7 +297,7 @@ while (unlikely_truthy_condition) [[unlikely]] {
 ```
 
 ### Deprecate implicit capture of this
-Implicitly capturing `this` in a lamdba capture using `[=]` is now deprecated; prefer capturing explicitly using `[=, this]` or `[=, *this]`.
+Implicitly capturing `this` in a lambda capture using `[=]` is now deprecated; prefer capturing explicitly using `[=, this]` or `[=, *this]`.
 ```c++
 struct int_value {
   int n = 0;

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ auto g = []<my_concept auto v> () {
   // ...
 };
 ```
-The `requires` keyword is used either to start a requires clause or a requires expression:
+The `requires` keyword is used either to start a `requires` clause or a `requires` expression:
 ```c++
 template <typename T>
   requires my_concept<T> // `requires` clause.
@@ -263,7 +263,7 @@ T add(T a, T b) {
   return a + b;
 }
 ```
-Note that the parameter list in a requires expression is optional. Each requirement in a requires expression are one of the following:
+Note that the parameter list in a `requires` expression is optional. Each requirement in a `requires` expression are one of the following:
 
 * **Simple requirements** - asserts that the given expression is valid.
 
@@ -392,7 +392,7 @@ while (unlikely_truthy_condition) [[unlikely]] {
 ```
 
 ### Deprecate implicit capture of this
-Implicitly capturing `this` in a lamdba capture using `[=]` is now deprecated; prefer capturing explicitly using `[=, this]` or `[=, *this]`.
+Implicitly capturing `this` in a lambda capture using `[=]` is now deprecated; prefer capturing explicitly using `[=, this]` or `[=, *this]`.
 ```c++
 struct int_value {
   int n = 0;
@@ -1254,7 +1254,7 @@ constexpr T e  = T(2.7182818284590452353);
 ```
 
 ### [[deprecated]] attribute
-C++14 introduces the `[[deprecated]]` attribute to indicate that a unit (function, class, etc) is discouraged and likely yield compilation warnings. If a reason is provided, it will be included in the warnings.
+C++14 introduces the `[[deprecated]]` attribute to indicate that a unit (function, class, etc.) is discouraged and likely yield compilation warnings. If a reason is provided, it will be included in the warnings.
 ```c++
 [[deprecated]]
 void old_method();
@@ -2205,7 +2205,7 @@ auto result = handle.get();  // wait for the result
 ```
 
 ### std::begin/end
-`std::begin` and `std::end` free functions were added to return begin and end iterators of a container generically. These functions also work with raw arrays which do not have begin and end member functions.
+`std::begin` and `std::end` free functions were added to return begin and end iterators of a container generically. These functions also work with raw arrays which do not have `begin` and `end` member functions.
 
 ```c++
 template <typename T>


### PR DESCRIPTION
* Fix typos.
* Fix small grammar mistakes.
* Fix link to `std::make_unique`, as it is absolute one.