### PR TITLE
C++17: Class template argument deduction

### DIFF
--- a/CPP17.md
+++ b/CPP17.md
@@ -383,7 +383,7 @@ struct container {
 };
 
 // deduction guide
-template <template Iter>
+template <typename Iter>
 container(Iter b, Iter e) -> container<typename std::iterator_traits<Iter>::value_type>;
 
 container a{ 7 }; // OK: deduces container<int>

--- a/README.md
+++ b/README.md
@@ -1047,7 +1047,7 @@ struct container {
 };
 
 // deduction guide
-template <template Iter>
+template <typename Iter>
 container(Iter b, Iter e) -> container<typename std::iterator_traits<Iter>::value_type>;
 
 container a{ 7 }; // OK: deduces container<int>


### PR DESCRIPTION
The user-defined deduction guide is incorrect and does not compile.

Instead of the repeated `template` keyword, the example requires `typename` or `class` inside the angle brackets.

See also [cppreference](https://en.cppreference.com/w/cpp/language/class_template_argument_deduction#User-defined_deduction_guides).