### PR TITLE
Fix 'propogate' typo and broken TOC anchor for std::optional monadic ops

### DIFF
--- a/CPP20.md
+++ b/CPP20.md
@@ -592,7 +592,7 @@ A span is a view (i.e. non-owning) of a container providing bounds-checked acces
 
 Spans can be dynamically-sized or fixed-sized (known as their *extent*). Fixed-sized spans benefit from bounds-checking.
 
-Span doesn't propogate const so to construct a read-only span use `std::span<const T>`.
+Span doesn't propagate const so to construct a read-only span use `std::span<const T>`.
 
 Example: using a dynamically-sized span to print integers from various containers.
 ```c++

--- a/CPP23.md
+++ b/CPP23.md
@@ -15,7 +15,7 @@ C++23 includes the following new library features:
 - [std::to_underlying](#stdto_underlying)
 - [`spanstream`](#spanstream)
 - [input/output pointers](#inputoutput-pointers)
-- [monadic operations for `std::optional`](monadic-operations-for-stdoptional)
+- [monadic operations for `std::optional`](#monadic-operations-for-stdoptional)
 - [`std::expected`](#stdexpected)
 - [`std::unreachable`](#stdunreachable)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ C++23 includes the following new library features:
 - [std::to_underlying](#stdto_underlying)
 - [`spanstream`](#spanstream)
 - [input/output pointers](#inputoutput-pointers)
-- [monadic operations for `std::optional`](monadic-operations-for-stdoptional)
+- [monadic operations for `std::optional`](#monadic-operations-for-stdoptional)
 - [`std::expected`](#stdexpected)
 - [`std::unreachable`](#stdunreachable)
 
@@ -914,7 +914,7 @@ A span is a view (i.e. non-owning) of a container providing bounds-checked acces
 
 Spans can be dynamically-sized or fixed-sized (known as their *extent*). Fixed-sized spans benefit from bounds-checking.
 
-Span doesn't propogate const so to construct a read-only span use `std::span<const T>`.
+Span doesn't propagate const so to construct a read-only span use `std::span<const T>`.
 
 Example: using a dynamically-sized span to print integers from various containers.
 ```c++


### PR DESCRIPTION
Two small fixes (applied in both the per-version files and the aggregated `README.md`):

1. **Typo:** `propogate` → `propagate` in the `std::span` const note (`CPP20.md` / `README.md`).

2. **Broken table-of-contents link:** the C++23 entry for *monadic operations for `std::optional`* was missing the leading `#`, so it linked to a (non-existent) relative file path instead of the in-page section anchor (`CPP23.md` / `README.md`):

   ```diff
   -- [monadic operations for `std::optional`](monadic-operations-for-stdoptional)
   +- [monadic operations for `std::optional`](#monadic-operations-for-stdoptional)
   ```

All other TOC entries already use the `#anchor` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)